### PR TITLE
allow clean update and build

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,14 +22,15 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-webgl": "^2.0.0",
+    "purescript-webgl": "^2.0.1",
     "purescript-clock": "^1.0.0",
     "purescript-random": "^3.0.0",
     "purescript-extensions": "^2.0.0",
     "purescript-console": "^3.0.0",
-    "purescript-matrix": "^1.0.0",
+    "purescript-matrix": "^2.0.0",
     "purescript-vector": "^2.0.0",
-    "purescript-typedarray": "^1.0.0"
+    "purescript-typedarray": "^2.0.0",
+    "purescript-datetime" : "^3.0.0"
   },
   "resolutions": {
     "purescript-arraybuffer-types": "^2.0.0"


### PR DESCRIPTION
Purescript 0.11.4 under Node 6

Hi, I may be missing an important point because part of this undoes the last commit. But I found that I had to make these changes to avoid an endless rabbit-hole of guessing at resolutions of bower version conflicts.